### PR TITLE
Remove internal inline imports

### DIFF
--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -94,6 +94,9 @@ function optimizeImports(txtBuffer: string): string {
   // remove internal imports
   result = result.replace(patterns.internalModule, "");
 
+  // remove internal inline imports
+  result = result.replace(patterns.internalInlineModule, "");
+
   const remaining = result.match(/\bimport\b/);
   if (remaining && remaining.length) {
     throw new Error(`optimizeImports() could not deal with the following: ${JSON.stringify(remaining, null, 2)}`);

--- a/src/lib/regexp-patterns.ts
+++ b/src/lib/regexp-patterns.ts
@@ -10,6 +10,9 @@ export const externalReExports = /^\s*export\s+[\*\{}\w\s\n, ]+\s+from\s['"].+['
 // Catching all: import ...;
 export const internalModule = /^(\s*import\s+.*;)$/gm;
 
+// example: import("./bar").Foo;
+export const internalInlineModule = /\b(import\(.*)\./gm;
+
 // example: import foo = barbar.thisIsFoo;
 export const internalModuleParts = /^import\s+([a-zA-Z]+)\s*=\s*([a-zA-Z\.0-9_]+);$/;
 


### PR DESCRIPTION
Thank you @nomaed for reaching out with #9! I've isolated the fix here, so meta changes such as package name and version will not be affected. Hope this is fine, I look forward to being able to go back to the original publication on npm instead of my modified one 😃 